### PR TITLE
Make sure that busybox pod gets into Completed state

### DIFF
--- a/charts/cert-manager-with-clusterissuer/templates/asleep-timeout.yaml
+++ b/charts/cert-manager-with-clusterissuer/templates/asleep-timeout.yaml
@@ -12,7 +12,7 @@ spec:
   - name: hook2-container
     image: busybox
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'echo post-install hook Pod is running - hook-postinstall && sleep 120']
+    command: ['sh', '-c', 'echo post-install hook Pod is running - hook-postinstall && sleep 120; exit 0']
   restartPolicy: Never
   terminationGracePeriodSeconds: 0
   # JIRA TICKET https://platform9.atlassian.net/browse/FT-178


### PR DESCRIPTION
busybox pod currently exits abruptly after 2 mins, thus rendering the helm watch in stuck state. It needs to get into completed state.

# kubectl get pods
post-install                                 0/1     Completed   0          2m4s