### PR TITLE
change delete policy for sleep pod

### DIFF
--- a/charts/cert-manager-with-clusterissuer/templates/asleep-timeout.yaml
+++ b/charts/cert-manager-with-clusterissuer/templates/asleep-timeout.yaml
@@ -6,7 +6,7 @@ metadata:
     app: wait
   annotations:
     "helm.sh/hook": "post-install"
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   containers:
   - name: hook2-container


### PR DESCRIPTION
This is in relation to a conversation with Mayuresh 
`another was the case where the post-install pod was getting deleted due to the: "helm.sh/hook-delete-policy": hook-succeeded, hook-failed policy, the post-install pod gets deleted in a few secs after successful pkg instalation but pf9helm which is running on the DU cannot get that notification in time and once the pod goes in Terminating state it fails.`