### PR TITLE
k8s.gcr.io is being deprecated for the newer registry.k8s.io

### DIFF
--- a/charts/nginx-ingress/nginx-ingress-with-lb/v0.46.0/values.yaml
+++ b/charts/nginx-ingress/nginx-ingress-with-lb/v0.46.0/values.yaml
@@ -10,7 +10,7 @@
 controller:
   name: controller
   image:
-    repository: k8s.gcr.io/ingress-nginx/controller
+    repository: registry.k8s.io/ingress-nginx/controller
     tag: "v0.46.0"
     digest: sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a
     pullPolicy: IfNotPresent
@@ -614,7 +614,7 @@ defaultBackend:
 
   name: defaultbackend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    repository: registry.k8s.io/defaultbackend-amd64
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534

--- a/charts/nginx-ingress/nginx-ingress-without-lb/v0.46.0/values.yaml
+++ b/charts/nginx-ingress/nginx-ingress-without-lb/v0.46.0/values.yaml
@@ -10,7 +10,7 @@
 controller:
   name: controller
   image:
-    repository: k8s.gcr.io/ingress-nginx/controller
+    repository: registry.k8s.io/ingress-nginx/controller
     tag: "v0.46.0"
     digest: sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a
     pullPolicy: IfNotPresent
@@ -611,7 +611,7 @@ defaultBackend:
 
   name: defaultbackend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    repository: registry.k8s.io/defaultbackend-amd64
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534


### PR DESCRIPTION
[PMK-5705](https://platform9.atlassian.net/browse/PMK-5705): k8s.gcr.io redirect to registry.k8s.io

k8s.gcr.io is being deprecated and moved to the newer community maintained registry.k8s.io

[PMK-5705]: https://platform9.atlassian.net/browse/PMK-5705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ